### PR TITLE
Send Webhooks only to apps that have been created.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -85,8 +85,9 @@ async function sendRequests(request, appURLs, path) {
                     /(^https:\/\/)|(^http:\/\/)|(\/$)/g,
                     ''
                 );
-
-                return axios.post(`${appURL}${path}`, request.body, {
+                const reviewAppWebhookUrl = `${appURL}${path}`;
+                console.log(`Sending request to: ${reviewAppWebhookUrl}`);
+                return axios.post(reviewAppWebhookUrl, request.body, {
                     headers,
                 });
             })

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -56,9 +56,9 @@ async function getApps(pipelineId) {
         const reviewAppsResponse = await axios.get(`${herokuBaseURL}${path}`, {
             headers: herokuRequestHeaders,
         });
-        reviewAppIds = reviewAppsResponse.data.map(
-            reviewApp => reviewApp.app.id
-        );
+        reviewAppIds = reviewAppsResponse.data
+            .filter(reviewApp => reviewApp.status == 'created')
+            .map(reviewApp => reviewApp.app.id);
     } catch (error) {
         // failed to get review apps for pipeline
         // error logging would go here, but for now just catch the error


### PR DESCRIPTION
- Limit webhook sending to `created` review apps.
- Add a log where the webhook is being sent to.